### PR TITLE
Fix Linux build: link libsecret-1 for @cImport

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,9 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const resolved_target = target.result;
+    const is_linux = resolved_target.os.tag == .linux;
+
     // Static library for C FFI
     const lib = b.addLibrary(.{
         .name = "zig-keychain",
@@ -14,6 +17,12 @@ pub fn build(b: *std.Build) void {
         }),
         .linkage = .static,
     });
+
+    // Link libsecret on Linux (needed for @cImport of libsecret/secret.h)
+    if (is_linux) {
+        lib.root_module.linkSystemLibrary("libsecret-1", .{});
+        lib.root_module.linkSystemLibrary("glib-2.0", .{});
+    }
 
     b.installArtifact(lib);
 
@@ -27,5 +36,11 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+
+    if (is_linux) {
+        t.root_module.linkSystemLibrary("libsecret-1", .{});
+        t.root_module.linkSystemLibrary("glib-2.0", .{});
+    }
+
     test_step.dependOn(&b.addRunArtifact(t).step);
 }


### PR DESCRIPTION
## Summary
- Link `libsecret-1` and `glib-2.0` system libraries on Linux so Zig can find `libsecret/secret.h` during `@cImport`
- Applies to both the static library and test targets
- Fixes Linux CI failures in cmux (Jesssullivan/cmux#103)